### PR TITLE
Chinook direction update

### DIFF
--- a/book-2-platform-api/chapters/CHINOOK.md
+++ b/book-2-platform-api/chapters/CHINOOK.md
@@ -2,19 +2,15 @@
 
 ## Downloading the Database Files
 
-Click the big download button from the [Chinook Database](http://chinookdatabase.codeplex.com/) site. Know which directory that it's being downloaded to.
+Click the download button from the [Chinook Database](https://github.com/lerocha/chinook-database/blob/master/ChinookDatabase/DataSources/Chinook_Sqlite.sqlite) github page and then open the database with DB browser and get querying! 
 
 ## Moving the SQLite Database to Your Workspace
 
-1. In your CLI, get to the directory where you extracted the archive. It should be something like the following.
-    ```
-    cd ~/Downloads/ChinookDatabase1.4_CompleteVersion
-    ```
 1. Create a directory for your work.
     ```
     mkdir -p ~/workspace/chinook
     ```
-2. Move the `Chinook_Sqlite.sqlite` file to that directory
+2. Move the `Chinook_Sqlite.sqlite` file that you downloaded to that directory
     ```
     cp Chinook_Sqlite.sqlite ~/workspace/chinook
     ```


### PR DESCRIPTION
Directions are cleaned up directing students to the Chinook github page to download the file instead of navigating the zip file and noise that comes with the confusing Chinook site. (compared to master at first by accident 🙄)