### PR TITLE
Changed the Kill Nickelback Exercise from using hashsets to now using Dictionaries, LINQ, and Lists

### DIFF
--- a/book-1-orientation/chapters/KILL_NICKELBACK.md
+++ b/book-1-orientation/chapters/KILL_NICKELBACK.md
@@ -1,6 +1,6 @@
 # Kill Nickelback
 
-In this exercise, you're going to use HashSets and Lists.
+In this exercise, you're going to use Dictionaries, LINQ, and Lists.
 
 ## Setup
 
@@ -12,17 +12,15 @@ dotnet restore
 
 ## Instructions
 
-1. Define a list of dictionaries.
-1. Each dictionary will have a key of type `string`, and a value of type `string`.
-1. Assign the list to a `goodSongs` variable.
-1. Define a HashSet, named `allSongs`, that contains 7 dictionaries.
-1. Each dictionary in the set will have a key of type `string`, and a value of type `string`.
+1. Define a List of Dictionaries, named `allSongs`, that contains 7 dictionaries.
+1. Each dictionary in the list will have a key of type `string`, and a value of type `string`.
 1. The key will be the name of an artist.
-1. The value will be the name of a song by that artist. Make sure that some of the songs are from the band Nickelback. You can see a [list of their greatest hits](https://www.amazon.com/Best-Nickelback-1/dp/B00FFERTUK/) on Amazon.
-    ```cs
-    // Example
-    HashSet<Dictionary<string, string>> allSongs = new HashSet<Dictionary<string, string>>();
-    ```
-1. Once the set is populated with 7 dictionaries, iterate over the set of songs, and check if the band name is "Nickelback".
-1. If the band is **not** Nickelback, then add it to the `goodSongs` list.
-1. Uee another `foreach` loop to print out all the good songs.
+1. The value will be the song title by that artist. Make sure that some of the songs are from the band Nickelback. You can see a [list of their greatest hits](https://www.amazon.com/Best-Nickelback-1/dp/B00FFERTUK/) on Amazon.
+   ```cs
+   // Example
+   List<Dictionary<string, string>> allSongs = new List<Dictionary<string, string>>();
+   ```
+1. Once the List is populated with 7 dictionaries, use LINQ methods, .Where() and .Select(), to check if the band name is "Nickelback".
+1. If the band is **not** Nickelback, then add it to a list of dictionaries with the variable name `goodSongs`.
+1. Make sure these artists in the `goodSongs` List are ordered alphabetically, in descending order (Z to A)
+1. Use a `foreach` loop to print out only the good songs.


### PR DESCRIPTION
In response to Issue Ticket #83, I removed hash sets to replace with lists of dictionaries and also added in LINQ to include where and order by.