### PR TITLE
Edited instructions to be more clear and fixed typos for the new Dictionary Exercises

### DIFF
--- a/book-1-orientation/chapters/DATA_STRUCTURES_DICTIONARY.md
+++ b/book-1-orientation/chapters/DATA_STRUCTURES_DICTIONARY.md
@@ -70,12 +70,12 @@ Dictionary<string, string> wordsAndDefinitions = new Dictionary<string, string>(
 wordsAndDefinitions.Add("Awesome", "The feeling of students when they are learning C#");
 
 /*
-    Use square bracket lookup to get the definition two
-    words and output them to the console
+    Use square brackets to get the definition of two of the
+    words and then output them to the console
 */
 
 /*
-    Loop over dictionary to get the following output:
+    Below, loop over the wordsAndDefinitions dictionary to get the following output:
         The definition of [WORD] is [DEFINITION]
         The definition of [WORD] is [DEFINITION]
         The definition of [WORD] is [DEFINITION]
@@ -108,7 +108,7 @@ List<Dictionary<string, string>> dictionaryOfWords = new List<Dictionary<string,
     }
 */
 
-// Create dictionary to represent a few word
+// Create dictionary to represent a few words
 Dictionary<string, string> excitedWord = new Dictionary<string, string>();
 
 // Add each of the 4 bits of data about the word to the Dictionary
@@ -121,7 +121,7 @@ excitedWord.Add();
 
 
 /*
-    Iterate your list of dictionaries and output the data
+    Iterate your list of dictionaries and output the data, You can use the two foreach() loops below to help you start your iteration.
 
     Example output for one word in the list of dictionaries:
         word: excited

--- a/book-1-orientation/chapters/DATA_STRUCTURES_DICTIONARY.md
+++ b/book-1-orientation/chapters/DATA_STRUCTURES_DICTIONARY.md
@@ -78,7 +78,7 @@ wordsAndDefinitions.Add("Awesome", "The feeling of students when they are learni
     Below, loop over the wordsAndDefinitions dictionary to get the following output:
         The definition of (WORD) is (DEFINITION)
         The definition of (WORD) is (DEFINITION)
-        The definition of (WORD) is (DEFINITION)        The definition of [WORD] is [DEFINITION]
+        The definition of (WORD) is (DEFINITION)
 */
 foreach (KeyValuePair<string, string> word in wordsAndDefinitions)
 {

--- a/book-1-orientation/chapters/DATA_STRUCTURES_DICTIONARY.md
+++ b/book-1-orientation/chapters/DATA_STRUCTURES_DICTIONARY.md
@@ -76,9 +76,9 @@ wordsAndDefinitions.Add("Awesome", "The feeling of students when they are learni
 
 /*
     Below, loop over the wordsAndDefinitions dictionary to get the following output:
-        The definition of [WORD] is [DEFINITION]
-        The definition of [WORD] is [DEFINITION]
-        The definition of [WORD] is [DEFINITION]
+        The definition of (WORD) is (DEFINITION)
+        The definition of (WORD) is (DEFINITION)
+        The definition of (WORD) is (DEFINITION)        The definition of [WORD] is [DEFINITION]
 */
 foreach (KeyValuePair<string, string> word in wordsAndDefinitions)
 {


### PR DESCRIPTION
This pull request references issue #156 

In the Practice: Dictionary of Words, students were getting confused by the square brackets around the last foreach example, so I replaced those with parentheses. I also fixed a few typos and tried to make it more clear that the "square bracket lookup" is a separate step than the foreach.
I tried to also make it more clear for students to use the nested foreach loops provided in Practice: List of Dictionaries about Words. 