### PR TITLE
added using System Collections

### DIFF
--- a/book-1-orientation/chapters/CSHARP_INTRO.md
+++ b/book-1-orientation/chapters/CSHARP_INTRO.md
@@ -65,6 +65,7 @@ Now replace your source code with the following.
 
 ```cs
 using System;
+using System.Collections.Generic;
 
 namespace bangazon
 {
@@ -147,7 +148,7 @@ for (int i=0; i<products.Count; i++) {
 
 # C# Conditions
 
-Luckily, the `if-then` syntax works exactly like it did in JavaScript. 
+Luckily, the `if-then` syntax works exactly like it did in JavaScript.
 Let's display a different message based on on the length of a product.
 
 ```cs


### PR DESCRIPTION
**Issue:** When trying to use List type, was receiving error: 

> The type or namespace name ‘List<>’ could not be found

**Fix:** Added `using System.Collections.Generic;` to resolve error when trying to use List type.


**Additional Fix:** Whitespace was also removed on autosave.
